### PR TITLE
Fix thread-safety bugs in web Middleware

### DIFF
--- a/lib/mem_health/middleware.rb
+++ b/lib/mem_health/middleware.rb
@@ -4,6 +4,7 @@ module MemHealth
 
     @@request_count = 0
     @@skipped_requests_count = 0
+    @@counter_mutex = Mutex.new
 
     def self.redis_tracked_requests_key
       "#{MemHealth.configuration.redis_key_prefix}:tracked_requests"
@@ -14,12 +15,13 @@ module MemHealth
     end
 
     def call(env)
-      @@request_count += 1
+      @@counter_mutex.synchronize { @@request_count += 1 }
 
       request = Rack::Request.new(env)
 
+      status = headers = response = nil
       metrics = measure_memory do
-        @status, @headers, @response = @app.call(env)
+        status, headers, response = @app.call(env)
       end
 
       # Skip the first few requests as they have large memory jumps due to class loading
@@ -40,15 +42,17 @@ module MemHealth
                            metadata.merge(execution_time: metrics[:execution_time]), type: :web)
         end
       else
-        @@skipped_requests_count += 1
+        @@counter_mutex.synchronize { @@skipped_requests_count += 1 }
       end
 
-      [@status, @headers, @response]
+      [status, headers, response]
     end
 
     def self.reset_data
-      @@request_count = 0
-      @@skipped_requests_count = 0
+      @@counter_mutex.synchronize do
+        @@request_count = 0
+        @@skipped_requests_count = 0
+      end
       MemHealth.configuration.redis.del(redis_tracked_requests_key)
     end
 


### PR DESCRIPTION
## Problem

In a multi-threaded server (Puma), `MemHealth::Middleware` corrupted request/responses.

Rack instantiates a middleware **once** and shares that single object across every thread. The old code stashed the upstream response in **instance variables**:

```ruby
@status, @headers, @response = @app.call(env)
# ...
[@status, @headers, @response]
```

Under concurrency, one thread could overwrite `@status`/`@headers`/`@response` between another thread's assignment and its return — so a request could be served a *different* request's response. Intermittent and invisible to single-threaded testing.

## Fix

- **Response corruption:** use local variables for `status`/`headers`/`response`, which are scoped per-`call` invocation and therefore per-thread.
- **Lost counts:** `@@request_count` / `@@skipped_requests_count` were incremented with `+=`, a non-atomic read-modify-write that drops counts under load. Guarded the increments and `reset_data` with a shared `@@counter_mutex`.

The reads (`total_requests_count` / `skipped_requests_count`) are single atomic loads and may read a momentarily-stale value, which is fine for a metric counter.

`JobTrackingMiddleware` was checked and is unaffected — it only uses local variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)