### PR TITLE
Fix ActiveJob job-class detection in JobTrackingMiddleware

### DIFF
--- a/lib/mem_health/job_tracking_middleware.rb
+++ b/lib/mem_health/job_tracking_middleware.rb
@@ -30,8 +30,14 @@ module MemHealth
     private
 
     def extract_job_class(worker, job)
-      # For ActiveJob jobs, extract the actual job class from the wrapper
-      if worker.class.name == 'ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper'
+      # For ActiveJob jobs, extract the actual job class from the wrapper.
+      # Detect via the payload's "wrapped" key rather than the wrapper's class
+      # name: on Sidekiq 7+/Rails 7.1+ the old
+      # ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper constant is just an
+      # alias whose #name resolves to "Sidekiq::ActiveJob::Wrapper", so the old
+      # string comparison never matched and every job was mislabeled as the
+      # wrapper. The "wrapped" key is what the sibling extractors key off too.
+      if job['wrapped'] # ActiveJob
         job['wrapped'] || job['args']&.first&.dig('job_class') || worker.class.name
       else
         worker.class.name

--- a/lib/mem_health/version.rb
+++ b/lib/mem_health/version.rb
@@ -1,3 +1,3 @@
 module MemHealth
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end


### PR DESCRIPTION
## Summary

`extract_job_class` detected ActiveJob jobs by comparing the wrapper's class name to `ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper`. On Sidekiq 7+/Rails 7.1+ that constant is just an alias for `Sidekiq::ActiveJob::Wrapper`, so `#name` resolves to the latter and the comparison never matched — every ActiveJob was mislabeled as the wrapper class instead of its real job class.

## Changes

- Detect ActiveJob via the payload's `"wrapped"` key instead of the wrapper class name, matching how `extract_job_args` and `extract_related_model` already work.
- Bump version `0.1.3` → `0.1.4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)